### PR TITLE
Fix example-scala by updating sbt and native-packager

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: target/start Web
+web: target/universal/stage/bin/example-scala

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,10 @@
-import com.typesafe.startscript.StartScriptPlugin
 
-seq(StartScriptPlugin.startScriptForClassesSettings: _*)
+enablePlugins(JavaAppPackaging)
 
-name := "hello"
+name := "example-scala"
 
-version := "1.0"
+version := "1.1"
 
-scalaVersion := "2.9.2"
+scalaVersion := "2.10.4"
 
-resolvers += "twitter-repo" at "http://maven.twttr.com"
-
-libraryDependencies ++= Seq("com.twitter" % "finagle-core" % "1.9.0", "com.twitter" % "finagle-http" % "1.9.0")
+libraryDependencies ++= Seq("com.twitter" % "finagle-http_2.10" % "6.18.0")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.0
+sbt.version=0.13.8

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,3 +1,0 @@
-resolvers += Classpaths.typesafeResolver
-
-addSbtPlugin("com.typesafe.startscript" % "xsbt-start-script-plugin" % "0.5.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0")

--- a/src/main/scala/web.scala
+++ b/src/main/scala/web.scala
@@ -1,30 +1,29 @@
-import org.jboss.netty.handler.codec.http.{HttpRequest, HttpResponse}
-import com.twitter.finagle.builder.ServerBuilder
-import com.twitter.finagle.http.{Http, Response}
-import com.twitter.finagle.Service
-import com.twitter.util.Future
-import java.net.InetSocketAddress
-import util.Properties
+import java.net.URI
+import java.sql.{Connection, DriverManager}
+
+import com.twitter.finagle.http.Response
+import com.twitter.finagle.{Http, Service}
+import com.twitter.util.{Await, Future}
+import org.jboss.netty.handler.codec.http._
+
+import scala.util.Properties
 
 object Web {
   def main(args: Array[String]) {
     val port = Properties.envOrElse("PORT", "8080").toInt
-    println("Starting on port:"+port)
-    ServerBuilder()
-      .codec(Http())
-      .name("hello-server")
-      .bindTo(new InetSocketAddress(port))
-      .build(new Hello)
-    println("Started.")
+    println("Starting on port: "+port)
+
+    val server = Http.serve(":" + port, new Hello)
+    Await.ready(server)
   }
 }
 
 class Hello extends Service[HttpRequest, HttpResponse] {
   val message : String = Properties.envOrElse("POWERED_BY", "Deis")
-  def apply(req: HttpRequest): Future[HttpResponse] = {
+  def apply(request: HttpRequest): Future[HttpResponse] = {
     val response = Response()
     response.setStatusCode(200)
-    response.setContentString("Powered by Scala+" + message)
+    response.setContentString("Powered by " + message)
     Future(response)
   }
 }

--- a/src/main/scala/web.scala
+++ b/src/main/scala/web.scala
@@ -20,14 +20,11 @@ object Web {
 }
 
 class Hello extends Service[HttpRequest, HttpResponse] {
-  var message : String = System.getenv("POWERED_BY")
-    if (message == null) {
-        message = "Deis";
-    }
+  val message : String = Properties.envOrElse("POWERED_BY", "Deis")
   def apply(req: HttpRequest): Future[HttpResponse] = {
     val response = Response()
     response.setStatusCode(200)
-    response.setContentString("Powered by " + message)
+    response.setContentString("Powered by Scala+" + message)
     Future(response)
   }
 }

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=1.7


### PR DESCRIPTION
The old packager this example app had been using is deprecated in favor of [sbt-native-packager](https://github.com/sbt/sbt-native-packager). Also includes the simplfying `var` -> `val` commit from #2.

Tested with Deis v1.5.2.

Closes deis/deis#3545.
